### PR TITLE
Issue 461: Update login page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ restart-apache:	## Restarts the Apache service
 restart-cas:	## Restarts the CAS service
 	docker-compose restart cas
 
+restart-cas-tomcat: ## Restarts the Tomcat instance running in the CAS container
+	docker exec $(CAS_CONTAINER_NAME) supervisorctl restart cas
+
 start:	## Starts up the application using Docker Compose
 	docker-compose up $(RUN_OPTIONS)
 

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ export CAS_CONTAINER_NAME = $(NAME_PREFIX)-cas
 export RUN_OPTIONS = 
 
 
-build:	## Builds application for Docker Compose
+build-images:	## Builds application for Docker Compose
 	docker-compose build
 
-build-nocache:	## Builds application for Docker Compose without the cache
+build-images-nocache:	## Builds application for Docker Compose without the cache
 	docker-compose build --no-cache
 
 destroy:	## Stops running app locally and removes Docker container images requiring a rebuild

--- a/cas/src/main/resources/templates/fragments/loginProviders.html
+++ b/cas/src/main/resources/templates/fragments/loginProviders.html
@@ -15,7 +15,11 @@
         <div th:if="${delegatedAuthenticationProviderUrls}" th:class="'auth-provider-cards d-md-flex'">
 
             <th:block th:each="entry: ${delegatedAuthenticationProviderUrls}">
-                <th:block th:insert="~{fragments/authProviders :: __${entry.name.toUpperCase()}__ (${entry.redirectUrl},${entry.autoRedirect})}"></th:block>
+
+                <th:block th:if="${entry.name.toUpperCase()} == 'ESA' OR ${entry.name.toUpperCase()} == 'URS'">
+                    <th:block th:insert="~{fragments/authProviders :: __${entry.name.toUpperCase()}__ (${entry.redirectUrl},${entry.autoRedirect})}"></th:block>
+                </th:block>
+
             </th:block>
 
         </div>

--- a/cas/src/main/resources/templates/fragments/loginProviders.html
+++ b/cas/src/main/resources/templates/fragments/loginProviders.html
@@ -15,7 +15,7 @@
         <div th:if="${delegatedAuthenticationProviderUrls}" th:class="'auth-provider-cards d-md-flex'">
 
             <th:block th:each="entry: ${delegatedAuthenticationProviderUrls}">
-                <th:block th:insert="~{fragments/authProviders :: __${entry.name.toUpperCase()}__ (${entry.redirectUrl},${entry.autoRedirect})}"></div>
+                <th:block th:insert="~{fragments/authProviders :: __${entry.name.toUpperCase()}__ (${entry.redirectUrl},${entry.autoRedirect})}"></th:block>
             </th:block>
 
         </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,4 @@ services:
     restart: on-failure
     volumes:
       - "./cas/src:/tmp/maap-auth-cas/src"
+      - "./cas/etc/cas:/etc/cas"


### PR DESCRIPTION
This pull request includes:

1. Updated `loginProviders.html` to fix an issue with the rendering of the UI on UAT where the ESA-API registered service is configured and shouldn't be displayed to the user.
2. Added additional makefile recipes for repeated tasks.
3. Added volume mount to `docker-compose.yml` so that config settings can be modified without having to rebuild the CAS image. This does require the Tomcat service to be restarted, which a make target was added to facilitate the restart.

@bsatoriu I've successfully deployed this to DIT. Since I don't have access to deploy to UAT, could you please review this code, and if it looks good, merge it in and deploy the WAR file that is on DIT located at `~/cas.war` to UAT?